### PR TITLE
Hao home page title now show username after greeting

### DIFF
--- a/frontend/src/main/components/css/HomePageTitle.css
+++ b/frontend/src/main/components/css/HomePageTitle.css
@@ -1,0 +1,14 @@
+@keyframes slideInFromLeft {
+    0% {
+      transform: translateX(-100%);
+      opacity: 0;
+    }
+    100% {
+      transform: translateX(0);
+      opacity: 1;
+    }
+  }
+  
+  .slide-in-animation {
+    animation: slideInFromLeft 1s ease-out forwards;
+  }

--- a/frontend/src/main/pages/AdminUsersPage.js
+++ b/frontend/src/main/pages/AdminUsersPage.js
@@ -7,6 +7,8 @@ const AdminUsersPage = () => {
 
     // const { data: users } = useUsers();
     const { data: users, isLoading, isError, error } = useUsers();
+    const abc = isLoading;
+    console.log(abc,"ascs");
     console.log(isLoading);
     console.log(isError);
     console.log(error);

--- a/frontend/src/main/pages/AdminUsersPage.js
+++ b/frontend/src/main/pages/AdminUsersPage.js
@@ -1,12 +1,14 @@
 import React from "react";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import UsersTable from "main/components/Users/UsersTable"
+import { useHistory } from 'react-router-dom';
 
 import { useUsers } from "main/utils/users";
 const AdminUsersPage = () => {
 
     // const { data: users } = useUsers();
     const { data: users, isLoading, isError, error } = useUsers();
+    const history = useHistory();
     if (isLoading) {
         history.push('/');
         return null; 

--- a/frontend/src/main/pages/AdminUsersPage.js
+++ b/frontend/src/main/pages/AdminUsersPage.js
@@ -6,23 +6,11 @@ import { useHistory } from 'react-router-dom';
 import { useUsers } from "main/utils/users";
 const AdminUsersPage = () => {
 
-    // const { data: users } = useUsers();
-    const { data: users, isLoading, isError, error } = useUsers();
-    const history = useHistory();
-    if (isLoading) {
-        history.push('/');
-        return null; 
-    }
-    const abc = isLoading;
-    console.log(abc,"ascs");
-    console.log(isLoading);
-    console.log(isError);
-    console.log(error);
+    const { data: users } = useUsers();
 
     return (
         <BasicLayout>
             <h2>Users</h2>
-            <div>{isLoading}</div>
             <UsersTable users={users} />
         </BasicLayout>
     );

--- a/frontend/src/main/pages/AdminUsersPage.js
+++ b/frontend/src/main/pages/AdminUsersPage.js
@@ -7,6 +7,10 @@ const AdminUsersPage = () => {
 
     // const { data: users } = useUsers();
     const { data: users, isLoading, isError, error } = useUsers();
+    if (isLoading) {
+        history.push('/');
+        return null; 
+    }
     const abc = isLoading;
     console.log(abc,"ascs");
     console.log(isLoading);

--- a/frontend/src/main/pages/AdminUsersPage.js
+++ b/frontend/src/main/pages/AdminUsersPage.js
@@ -1,7 +1,6 @@
 import React from "react";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import UsersTable from "main/components/Users/UsersTable"
-import { useHistory } from 'react-router-dom';
 
 import { useUsers } from "main/utils/users";
 const AdminUsersPage = () => {

--- a/frontend/src/main/pages/AdminUsersPage.js
+++ b/frontend/src/main/pages/AdminUsersPage.js
@@ -5,11 +5,14 @@ import UsersTable from "main/components/Users/UsersTable"
 import { useUsers } from "main/utils/users";
 const AdminUsersPage = () => {
 
-    const { data: users } = useUsers();
+    // const { data: users } = useUsers();
+    const { data: users, isLoading, isError, error } = useUsers();
+    console.log(isLoading);
 
     return (
         <BasicLayout>
             <h2>Users</h2>
+            <div>{isLoading}</div>
             <UsersTable users={users} />
         </BasicLayout>
     );

--- a/frontend/src/main/pages/AdminUsersPage.js
+++ b/frontend/src/main/pages/AdminUsersPage.js
@@ -8,6 +8,8 @@ const AdminUsersPage = () => {
     // const { data: users } = useUsers();
     const { data: users, isLoading, isError, error } = useUsers();
     console.log(isLoading);
+    console.log(isError);
+    console.log(error);
 
     return (
         <BasicLayout>

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -8,6 +8,7 @@ import { useBackend, useBackendMutation } from "main/utils/useBackend";
 import { useCurrentUser } from "main/utils/currentUser";
 import Background from './../../assets/HomePageBackground.jpg';
 import { commonsNotJoined } from "main/utils/commonsUtils";
+import "main/components/css/HomePageTitle.css";
 
 export default function HomePage() {
   const [commonsJoined, setCommonsJoined] = useState([]);
@@ -59,7 +60,7 @@ export default function HomePage() {
   return (
     <div data-testid={"HomePage-main-div"} style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})` }}>
       <BasicLayout>
-        <h1 data-testid="homePage-title" style={{ fontSize: "75px", borderRadius: "7px", backgroundColor: "white", opacity: ".9" }} className="text-center border-0 my-3">Howdy Farmer</h1>
+        <h1 data-testid="homePage-title" style={{ fontSize: "75px", borderRadius: "7px", backgroundColor: "white", opacity: ".9" }} className="text-center border-0 my-3 slide-in-animation">Howdy Farmer</h1>
         <Container>
           <Row>
             <Col sm><CommonsList commonList={commonsJoined} title="Visit A Commons" buttonText={"Visit"} buttonLink={visitButtonClick} /></Col>

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -56,11 +56,17 @@ export default function HomePage() {
   //create a list of commons that the user hasn't joined for use in the "Join a New Commons" list.
  
   const commonsNotJoinedList = commonsNotJoined(commons, commonsJoined);
+
+  let userFullName = "";
+  if (currentUser?.root?.user) {
+    const { firstName, lastName } = currentUser.root.user;
+    userFullName = ` ${firstName} ${lastName}`;
+  }
   
   return (
     <div data-testid={"HomePage-main-div"} style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})` }}>
       <BasicLayout>
-        <h1 data-testid="homePage-title" style={{ fontSize: "75px", borderRadius: "7px", backgroundColor: "white", opacity: ".9" }} className="text-center border-0 my-3 slide-in-animation">Howdy Farmer</h1>
+        <h1 data-testid="homePage-title" style={{ fontSize: "75px", borderRadius: "7px", backgroundColor: "white", opacity: ".9" }} className="text-center border-0 my-3 slide-in-animation">Howdy Farmer {userFullName}</h1>
         <Container>
           <Row>
             <Col sm><CommonsList commonList={commonsJoined} title="Visit A Commons" buttonText={"Visit"} buttonLink={visitButtonClick} /></Col>

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -66,7 +66,7 @@ export default function HomePage() {
   return (
     <div data-testid={"HomePage-main-div"} style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})` }}>
       <BasicLayout>
-        <h1 data-testid="homePage-title" style={{ fontSize: "75px", borderRadius: "7px", backgroundColor: "white", opacity: ".9" }} className="text-center border-0 my-3 slide-in-animation">Howdy Farmer {userFullName}</h1>
+        <h1 data-testid="homePage-title" style={{ fontSize: "75px", borderRadius: "7px", backgroundColor: "white", opacity: ".9" }} className="text-center border-0 my-3 slide-in-animation">Howdy Farmer{userFullName}</h1>
         <Container>
           <Row>
             <Col sm><CommonsList commonList={commonsJoined} title="Visit A Commons" buttonText={"Visit"} buttonLink={visitButtonClick} /></Col>

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -59,8 +59,8 @@ export default function HomePage() {
 
   let userFullName = "";
   if (currentUser?.root?.user) {
-    const { firstName, lastName } = currentUser.root.user;
-    userFullName = ` ${firstName} ${lastName}`;
+    const { givenName, familyName } = currentUser.root.user;
+    userFullName = ` ${givenName} ${familyName}`;
   }
   
   return (

--- a/frontend/src/tests/pages/HomePage.test.js
+++ b/frontend/src/tests/pages/HomePage.test.js
@@ -66,8 +66,7 @@ describe("HomePage tests", () => {
         expect(mainDiv).toBeInTheDocument();
         expect(mainDiv).toHaveAttribute("style", "background-size: cover; background-image: url(HomePageBackground.jpg);");
 
-        await waitFor(() => expect(screen.getByTestId("homePage-title")).toBeInTheDocument());
-        const title = screen.getByTestId("homePage-title");
+        const title = await screen.findByTestId("homePage-title");
         expect(title).toBeInTheDocument();
         expect(typeof (title.textContent)).toBe('string');
         expect(title.textContent).toEqual('Howdy Farmer Phillip Conrad');
@@ -102,8 +101,7 @@ describe("HomePage tests", () => {
             </QueryClientProvider>
         );
 
-        await waitFor(() => expect(screen.getByTestId("homePage-title")).toBeInTheDocument());
-        const title = screen.getByTestId("homePage-title");
+        const title = await screen.findByTestId("homePage-title");
         expect(title).toBeInTheDocument();
         expect(typeof (title.textContent)).toBe('string');
         expect(title.textContent).toEqual('Howdy Farmer Phillip Conrad');

--- a/frontend/src/tests/pages/HomePage.test.js
+++ b/frontend/src/tests/pages/HomePage.test.js
@@ -68,7 +68,7 @@ describe("HomePage tests", () => {
         const title = screen.getByTestId("homePage-title");
         expect(title).toBeInTheDocument();
         expect(typeof (title.textContent)).toBe('string');
-        expect(title.textContent).toEqual('Howdy Farmer');
+        expect(title.textContent).toEqual('Howdy Farmer Phillip Conrad');
 
         expect(() => screen.getAllByTestId(/commonsCard-button/)).toThrow('Unable to find an element');
     });
@@ -103,7 +103,7 @@ describe("HomePage tests", () => {
         const title = screen.getByTestId("homePage-title");
         expect(title).toBeInTheDocument();
         expect(typeof (title.textContent)).toBe('string');
-        expect(title.textContent).toEqual('Howdy Farmer');
+        expect(title.textContent).toEqual('Howdy Farmer Phillip Conrad');
     });
 
     test("Redirects to the PlayPage when you click visit", async () => {

--- a/frontend/src/tests/pages/HomePage.test.js
+++ b/frontend/src/tests/pages/HomePage.test.js
@@ -207,4 +207,26 @@ describe("HomePage tests", () => {
         expect(title.textContent).toEqual('Howdy Farmer');
     });
 
+    test("renders greeting without a name when currentUser.root.user is null", () => {
+        const mockUser = {
+            root: {
+                user: null
+            }
+        };
+        axiosMock.onGet("/api/currentUser").reply(200, mockUser);
+        axiosMock.onGet("/api/commons/all").reply(200, []);
+        
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <HomePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    
+        const title = screen.getByTestId("homePage-title");
+        expect(title.textContent).toEqual('Howdy Farmer');
+    });
+    
+
 });

--- a/frontend/src/tests/pages/HomePage.test.js
+++ b/frontend/src/tests/pages/HomePage.test.js
@@ -155,8 +155,24 @@ describe("HomePage tests", () => {
     
     });
 
-    test("renders greeting without a name when currentUser is undefined", () => {
+    test("renders greeting without a name when currentUser is null", () => {
         axiosMock.onGet("/api/currentUser").reply(200, null);
+        axiosMock.onGet("/api/commons/all").reply(200, []);
+        
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <HomePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    
+        const title = screen.getByTestId("homePage-title");
+        expect(title.textContent).toEqual('Howdy Farmer');
+    });
+
+    test("renders greeting without a name when currentUser is undefined", () => {
+        axiosMock.onGet("/api/currentUser").reply(200, undefined);
         axiosMock.onGet("/api/commons/all").reply(200, []);
         
         render(

--- a/frontend/src/tests/pages/HomePage.test.js
+++ b/frontend/src/tests/pages/HomePage.test.js
@@ -154,6 +154,20 @@ describe("HomePage tests", () => {
     
     });
 
-
+    test("displays user's full name when givenName and familyName are present", () => {
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/commons/all").reply(200, []);
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <HomePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    
+        const title = screen.getByTestId("homePage-title");
+        expect(title).toBeInTheDocument();
+        expect(title.textContent).toEqual('Howdy Farmer Phillip Conrad');
+    });
 
 });


### PR DESCRIPTION
In this PR, I added the display of user's full name after the greeting "Howdy Farmer."
![image](https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-1/assets/33027568/d0119931-52a8-4c91-9dee-ef0423aa201c)
To test, go to https://happiercow-haostevewu.dokku-04.cs.ucsb.edu/ and log in, then the title should show your full name after Howdy Farmer.
Closes #31 