### PR TITLE
Ethan - Add CapacityPerUser Field to Commons

### DIFF
--- a/frontend/src/fixtures/commonsFixtures.js
+++ b/frontend/src/fixtures/commonsFixtures.js
@@ -12,6 +12,7 @@ const commonsFixtures = {
             "degradationRate": .5,
             "showLeaderboard": true,
             "carryingCapacity": 100,
+            "capacityPerUser": 10,
             "belowCapacityHealthUpdateStrategy": "Noop",
             "aboveCapacityHealthUpdateStrategy": "Noop"
         },
@@ -27,6 +28,7 @@ const commonsFixtures = {
             "degradationRate": .5,
             "showLeaderboard": true,
             "carryingCapacity": 123,
+            "capacityPerUser": 11,
             "belowCapacityHealthUpdateStrategy": "Linear",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         },
@@ -42,6 +44,7 @@ const commonsFixtures = {
             "degradationRate": .5,
             "showLeaderboard": true,
             "carryingCapacity": 42,
+            "capacityPerUser": 13,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         }
@@ -59,6 +62,8 @@ const commonsFixtures = {
                 "milkPrice": 10,
                 "degradationRate": .5,
                 "showLeaderboard": true,
+                "capacityPerUser": 5,
+                
                 "carryingCapacity": 314,
                 "belowCapacityHealthUpdateStrategy": "Constant",
                 "aboveCapacityHealthUpdateStrategy": "Linear"
@@ -75,6 +80,7 @@ const commonsFixtures = {
             "degradationRate": .5,
             "showLeaderboard": true,
             "carryingCapacity": 100,
+            "capacityPerUser": 1,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         },
@@ -87,6 +93,7 @@ const commonsFixtures = {
             "degradationRate": .5,
             "showLeaderboard": true,
             "carryingCapacity": 100,
+            "capacityPerUser": 5,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         },
@@ -99,6 +106,7 @@ const commonsFixtures = {
             "degradationRate": .5,
             "showLeaderboard": true,
             "carryingCapacity": 100,
+            "capacityPerUser": 5,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         },
@@ -111,6 +119,7 @@ const commonsFixtures = {
             "degradationRate": .5,
             "showLeaderboard": true,
             "carryingCapacity": 100,
+            "capacityPerUser": 2,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         },
@@ -123,6 +132,7 @@ const commonsFixtures = {
             "degradationRate": .5,
             "showLeaderboard": true,
             "carryingCapacity": 100,
+            "capacityPerUser": 2,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         },
@@ -135,6 +145,7 @@ const commonsFixtures = {
             "degradationRate": .5,
             "showLeaderboard": true,
             "carryingCapacity": 100,
+            "capacityPerUser": 2,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         },
@@ -147,6 +158,7 @@ const commonsFixtures = {
             "degradationRate": .5,
             "showLeaderboard": true,
             "carryingCapacity": 100,
+            "capacityPerUser": 2,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         }

--- a/frontend/src/fixtures/commonsPlusFixtures.js
+++ b/frontend/src/fixtures/commonsPlusFixtures.js
@@ -12,6 +12,7 @@ const commonsPlusFixtures = {
                 "degradationRate": 0.01,
                 "showLeaderboard": false,
                 "carryingCapacity": 100,
+                "capacityPerUser": 50,
             },
             "totalCows": 10,
             "totalUsers": 2
@@ -29,6 +30,7 @@ const commonsPlusFixtures = {
                 "degradationRate": 0.01,
                 "showLeaderboard": true,
                 "carryingCapacity": 42,
+                "capacityPerUser": 5,
             },
             "totalCows": 0,
             "totalUsers": 1
@@ -46,6 +48,7 @@ const commonsPlusFixtures = {
                 "degradationRate": 5.0,
                 "showLeaderboard": true,
                 "carryingCapacity": 123,
+                "capacityPerUser": 50,
             },
             "totalCows": 0,
             "totalUsers": 1
@@ -66,6 +69,7 @@ const commonsPlusFixtures = {
                 "degradationRate": 3.0,
                 "showLeaderboard": false,
                 "carryingCapacity": 23,
+                "capacityPerUser": 1,
             },
             "totalCows": 0,
             "totalUsers": 0

--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -196,6 +196,24 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
         </Form.Group>
       </Row>
 
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="capacityPerUser">Capacity Per User</Form.Label>
+        <Form.Control
+          data-testid={`${testid}-capacityPerUser`}
+          id="capacityPerUser"
+          type="number"
+          step="1"
+          isInvalid={!!errors.capacityPerUser}
+          {...register("capacityPerUser", {
+            valueAsNumber: true,
+            required: "Capacity Per User is required",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.capacityPerUser?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
       <h4>
         Health update formula
       </h4>

--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -75,7 +75,12 @@ export default function CommonsTable({ commons, currentUser }) {
             Header: 'Carrying Capacity',
             accessor: row => row.commons.carryingCapacity,
             id: 'commons.carryingCapacity'
-        }
+        },
+        {
+            Header: 'Capacity Per User',
+            accessor: row => row.commons.capacityPerUser,
+            id: 'commons.capacityPerUser'
+        },
     ];
 
     const testid = "CommonsTable";

--- a/frontend/src/main/pages/AdminCreateCommonsPage.js
+++ b/frontend/src/main/pages/AdminCreateCommonsPage.js
@@ -21,6 +21,7 @@ const AdminCreateCommonsPage = () => {
             <br />{`startDate: ${commons.startingDate}`}
             <br />{`cowPrice: ${commons.cowPrice}`}
             <br />{`carryingCapacity: ${commons.carryingCapacity}`}
+            <br />{`capacityPerUser: ${commons.capacityPerUser}`}
         </div>);
     }
    

--- a/frontend/src/main/pages/AdminEditCommonsPage.js
+++ b/frontend/src/main/pages/AdminEditCommonsPage.js
@@ -36,6 +36,7 @@ export default function CommonsEditPage() {
         "startingDate": commons.startingDate,
         "degradationRate": commons.degradationRate,
         "carryingCapacity": commons.carryingCapacity,
+        "capacityPerUser": commons.capacityPerUser,
         "aboveCapacityHealthUpdateStrategy": commons.aboveCapacityHealthUpdateStrategy,
         "belowCapacityHealthUpdateStrategy": commons.belowCapacityHealthUpdateStrategy,
         "showLeaderboard": commons.showLeaderboard,

--- a/frontend/src/tests/components/Commons/CommonsForm.test.js
+++ b/frontend/src/tests/components/Commons/CommonsForm.test.js
@@ -49,6 +49,7 @@ describe("CommonsForm tests", () => {
       /Starting Date/,
       /Degradation Rate/,
       /Carrying Capacity/,
+      /Capacity Per User/,
       /Show Leaderboard\?/,
       /When below capacity/,
       /When above capacity/,
@@ -105,6 +106,7 @@ describe("CommonsForm tests", () => {
     expect(screen.getByTestId("CommonsForm-startingDate")).not.toHaveClass("is-invalid");
     expect(screen.getByTestId("CommonsForm-degradationRate")).not.toHaveClass("is-invalid");
     expect(screen.getByTestId("CommonsForm-carryingCapacity")).not.toHaveClass("is-invalid");
+    expect(screen.getByTestId("CommonsForm-capacityPerUser",)).not.toHaveClass("is-invalid");
 
     fireEvent.change(screen.getByTestId("CommonsForm-name"), { target: { value: "" } });
     fireEvent.change(screen.getByTestId("CommonsForm-startingBalance"), { target: { value: "" } });
@@ -113,6 +115,7 @@ describe("CommonsForm tests", () => {
     fireEvent.change(screen.getByTestId("CommonsForm-startingDate"), { target: { value: "" } });
     fireEvent.change(screen.getByTestId("CommonsForm-degradationRate"), { target: { value: "" } });
     fireEvent.change(screen.getByTestId("CommonsForm-carryingCapacity"), { target: { value: "" } });
+    fireEvent.change(screen.getByTestId("CommonsForm-capacityPerUser"), { target: { value: "" } });
     fireEvent.click(submitButton);
 
     expect(await screen.findByText(/commons name is required/i)).toBeInTheDocument();
@@ -122,6 +125,7 @@ describe("CommonsForm tests", () => {
     expect(screen.getByText(/starting date is required/i)).toBeInTheDocument();
     expect(screen.getByText(/degradation rate is required/i)).toBeInTheDocument();
     expect(screen.getByText(/Carrying capacity is required/i)).toBeInTheDocument();
+    expect(screen.getByText(/Capacity Per User is required/i)).toBeInTheDocument();
 
     // check that the other testids are present
 

--- a/frontend/src/tests/components/Commons/CommonsTable.test.js
+++ b/frontend/src/tests/components/Commons/CommonsTable.test.js
@@ -69,8 +69,8 @@ describe("UserTable tests", () => {
 
     );
 
-    const expectedHeaders = ["id", "Name", "Cow Price", 'Milk Price', 'Starting Balance', 'Starting Date', 'Degradation Rate', 'Carrying Capacity', 'Cows', 'Show Leaderboard?'];
-    const expectedFields = ["id", "name", "cowPrice", "milkPrice", "startingBalance", "startingDate", "degradationRate", "carryingCapacity"];
+    const expectedHeaders = ["id", "Name", "Cow Price", 'Milk Price', 'Starting Balance', 'Starting Date', 'Degradation Rate', 'Carrying Capacity', 'Capacity Per User', 'Cows', 'Show Leaderboard?'];
+    const expectedFields = ["id", "name", "cowPrice", "milkPrice", "startingBalance", "startingDate", "degradationRate", "carryingCapacity", "capacityPerUser"];
     const testId = "CommonsTable";
 
     expectedHeaders.forEach((headerText) => {
@@ -92,6 +92,7 @@ describe("UserTable tests", () => {
     expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.milkPrice`)).toHaveTextContent("2");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.degradationRate`)).toHaveTextContent("0.01");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.carryingCapacity`)).toHaveTextContent("42");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.capacityPerUser`)).toHaveTextContent("5");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.startingBalance`)).toHaveTextContent("10");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.startingDate`)).toHaveTextContent(/^2022-11-22$/); // regex so that we have an exact match https://stackoverflow.com/a/73298371
     expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.showLeaderboard`)).toHaveTextContent("true");

--- a/frontend/src/tests/pages/AdminCreateCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminCreateCommonsPage.test.js
@@ -65,6 +65,7 @@ describe("AdminCreateCommonsPage tests", () => {
             "startingDate": "2022-03-05T00:00:00",
             "degradationRate": 30.4,
             "carryingCapacity": 25,
+            "capacityPerUser": 10,
             "aboveCapacityHealthUpdateStrategy": "strat2",
             "belowCapacityHealthUpdateStrategy": "strat3",
             "showLeaderboard": false,
@@ -87,6 +88,7 @@ describe("AdminCreateCommonsPage tests", () => {
         const startDateField = screen.getByLabelText("Starting Date");
         const degradationRateField = screen.getByLabelText("Degradation Rate");
         const carryingCapacityField = screen.getByLabelText("Carrying Capacity");
+        const capacityPerUserField = screen.getByLabelText("Capacity Per User");
         const aboveCapacityHealthUpdateStrategyField = screen.getByLabelText("When above capacity");
         const belowCapacityHealthUpdateStrategyField = screen.getByLabelText("When below capacity");
         const showLeaderboardField = screen.getByLabelText("Show Leaderboard?");
@@ -99,6 +101,7 @@ describe("AdminCreateCommonsPage tests", () => {
         fireEvent.change(startDateField, { target: { value: '2022-03-05' } })
         fireEvent.change(degradationRateField, { target: { value: '30.4' } })
         fireEvent.change(carryingCapacityField, { target: { value: '25' } })
+        fireEvent.change(capacityPerUserField, { target: { value: '10' } })
         fireEvent.change(showLeaderboardField, { target: { value: true } })
 
         fireEvent.change(aboveCapacityHealthUpdateStrategyField, { target: {value: 'strat2' } })
@@ -119,6 +122,7 @@ describe("AdminCreateCommonsPage tests", () => {
             startingDate: '2022-03-05T00:00:00.000Z', // [1]
             degradationRate: 30.4,
             carryingCapacity: 25,
+            capacityPerUser: 10,
             showLeaderboard: false,
             aboveCapacityHealthUpdateStrategy: "strat2",
             belowCapacityHealthUpdateStrategy: "strat3",
@@ -132,6 +136,7 @@ describe("AdminCreateCommonsPage tests", () => {
             <br />startDate: 2022-03-05T00:00:00
             <br />cowPrice: 10
             <br />carryingCapacity: 25
+            <br />capacityPerUser: 10
         </div>);
 
         expect(mockedNavigate).toBeCalledWith({"to": "/"});

--- a/frontend/src/tests/pages/AdminEditCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminEditCommonsPage.test.js
@@ -51,6 +51,7 @@ describe("AdminEditCommonsPage tests", () => {
                 "milkPrice": 10,
                 "degradationRate": 20.3,
                 "carryingCapacity": 100,
+                "capacityPerUser": 10,
                 "showLeaderboard": false,
                 "aboveCapacityHealthUpdateStrategy": "strat1",
                 "belowCapacityHealthUpdateStrategy": "strat2"
@@ -64,6 +65,7 @@ describe("AdminEditCommonsPage tests", () => {
                 "milkPrice": 5,
                 "degradationRate": 40.3,
                 "carryingCapacity": 200,
+                "capacityPerUser": 20,
                 "showLeaderboard": false,
                 "aboveCapacityHealthUpdateStrategy": "strat2",
                 "belowCapacityHealthUpdateStrategy": "strat3"
@@ -99,6 +101,7 @@ describe("AdminEditCommonsPage tests", () => {
             const startingDateField = screen.getByLabelText(/Starting Date/);
             const degradationRateField = screen.getByLabelText(/Degradation Rate/);
             const carryingCapacityField = screen.getByLabelText(/Carrying Capacity/);
+            const capacityPerUserField = screen.getByLabelText(/Capacity Per User/);
             const aboveCapacityHealthUpdateStrategyField = screen.getByLabelText(/When above capacity/);
             const belowCapacityHealthUpdateStrategyField = screen.getByLabelText(/When below capacity/);
             const showLeaderboardField = screen.getByLabelText(/Show Leaderboard\?/);
@@ -110,6 +113,7 @@ describe("AdminEditCommonsPage tests", () => {
             expect(milkPriceField).toHaveValue(10);
             expect(degradationRateField).toHaveValue(20.3);
             expect(carryingCapacityField).toHaveValue(100);
+            expect(capacityPerUserField).toHaveValue(10);
             expect(aboveCapacityHealthUpdateStrategyField).toHaveValue("strat1");
             expect(belowCapacityHealthUpdateStrategyField).toHaveValue("strat2");
             expect(showLeaderboardField).not.toBeChecked();
@@ -133,6 +137,7 @@ describe("AdminEditCommonsPage tests", () => {
             const startingDateField = screen.getByLabelText(/Starting Date/);
             const degradationRateField = screen.getByLabelText(/Degradation Rate/);
             const carryingCapacityField = screen.getByLabelText(/Carrying Capacity/);
+            const capacityPerUserField = screen.getByLabelText(/Capacity Per User/);
             const aboveCapacityHealthUpdateStrategyField = screen.getByLabelText(/When above capacity/);
             const belowCapacityHealthUpdateStrategyField = screen.getByLabelText(/When below capacity/);
             const showLeaderboardField = screen.getByLabelText(/Show Leaderboard\?/);
@@ -144,6 +149,7 @@ describe("AdminEditCommonsPage tests", () => {
             expect(milkPriceField).toHaveValue(10);
             expect(degradationRateField).toHaveValue(20.3);
             expect(carryingCapacityField).toHaveValue(100);
+            expect(capacityPerUserField).toHaveValue(10);
             expect(aboveCapacityHealthUpdateStrategyField).toHaveValue("strat1");
             expect(belowCapacityHealthUpdateStrategyField).toHaveValue("strat2");
             expect(showLeaderboardField).not.toBeChecked();
@@ -159,6 +165,7 @@ describe("AdminEditCommonsPage tests", () => {
             fireEvent.change(milkPriceField, { target: { value: 5 } })
             fireEvent.change(degradationRateField, { target: { value: 40.3 } })
             fireEvent.change(carryingCapacityField, { target: { value: 200 } })
+            fireEvent.change(capacityPerUserField, { target: { value: 20 } })
             fireEvent.change(aboveCapacityHealthUpdateStrategyField, { target: { value: "strat2" } })
             fireEvent.change(belowCapacityHealthUpdateStrategyField, { target: { value: "strat3" } })
             fireEvent.click(showLeaderboardField)
@@ -179,6 +186,7 @@ describe("AdminEditCommonsPage tests", () => {
                 "startingDate": "2022-03-07T00:00:00.000Z",
                 "degradationRate": 40.3,
                 "carryingCapacity": 200,
+                "capacityPerUser": 20,
                 "aboveCapacityHealthUpdateStrategy": "strat2",
                 "belowCapacityHealthUpdateStrategy": "strat3",
                 "showLeaderboard": true,

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -110,6 +110,7 @@ public class CommonsController extends ApiController {
         updated.setShowLeaderboard(params.getShowLeaderboard());
         updated.setDegradationRate(params.getDegradationRate());
         updated.setCarryingCapacity(params.getCarryingCapacity());
+        updated.setCapacityPerUser(params.getCapacityPerUser());
         if (params.getAboveCapacityHealthUpdateStrategy() != null) {
             updated.setAboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.valueOf(params.getAboveCapacityHealthUpdateStrategy()));
         }
@@ -153,7 +154,8 @@ public class CommonsController extends ApiController {
                 .startingDate(params.getStartingDate())
                 .degradationRate(params.getDegradationRate())
                 .showLeaderboard(params.getShowLeaderboard())
-                .carryingCapacity(params.getCarryingCapacity());
+                .carryingCapacity(params.getCarryingCapacity())
+                .capacityPerUser(params.getCapacityPerUser());
 
         // ok to set null values for these, so old backend still works
         if (params.getAboveCapacityHealthUpdateStrategy() != null) {

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -30,6 +30,7 @@ public class Commons {
     private boolean showLeaderboard;
 
     private int carryingCapacity;
+    private int capacityPerUser;
     private double degradationRate;
 
     // these defaults match old behavior

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
@@ -25,6 +25,8 @@ public class CreateCommonsParams {
     @NumberFormat
     private int carryingCapacity;
     @NumberFormat
+    private int capacityPerUser;
+    @NumberFormat
     private double degradationRate;
 
     private String aboveCapacityHealthUpdateStrategy;

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -66,6 +67,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(50.0)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(10)
                 .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant)
                 .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
                 .build();
@@ -79,6 +81,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(50.0)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(10)
                 .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant.name())
                 .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear.name())
                 .build();
@@ -117,6 +120,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(50.0)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(10)
                 .build();
 
         CreateCommonsParams parameters = CreateCommonsParams.builder()
@@ -128,6 +132,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(50.0)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(10)
                 .build();
 
         // don't include null values to simulate old frontend
@@ -167,6 +172,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(0)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(10)
                 .build();
 
         CreateCommonsParams parameters = CreateCommonsParams.builder()
@@ -178,6 +184,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(0)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(10)
                 .build();
 
         String requestBody = objectMapper.writeValueAsString(parameters);
@@ -213,6 +220,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingDate(someTime)
                 .degradationRate(-8.49)
                 .carryingCapacity(100)
+                .capacityPerUser(10)
                 .build();
 
         CreateCommonsParams parameters = CreateCommonsParams.builder()
@@ -223,6 +231,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingDate(someTime)
                 .degradationRate(-8.49)
                 .carryingCapacity(100)
+                .capacityPerUser(10)
                 .build();
 
         String requestBody = objectMapper.writeValueAsString(parameters);
@@ -273,6 +282,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(50.0)
                 .showLeaderboard(true)
                 .carryingCapacity(100)
+                .capacityPerUser(10)
                 .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant.name())
                 .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear.name())
                 .build();
@@ -286,6 +296,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(50.0)
                 .showLeaderboard(true)
                 .carryingCapacity(100)
+                .capacityPerUser(10)
                 .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant)
                 .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
                 .build();
@@ -312,6 +323,8 @@ public class CommonsControllerTests extends ControllerTestCase {
         commons.setShowLeaderboard(parameters.getShowLeaderboard());
         parameters.setCarryingCapacity(123);
         commons.setCarryingCapacity(parameters.getCarryingCapacity());
+        parameters.setCapacityPerUser(12);
+        commons.setCapacityPerUser(parameters.getCapacityPerUser());
         parameters.setAboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear.name());
         commons.setAboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear);
         parameters.setBelowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Noop.name());
@@ -349,6 +362,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(50.0)
                 .showLeaderboard(true)
                 .carryingCapacity(100)
+                .capacityPerUser(10)
                 .build();
 
         Commons commons = Commons.builder()
@@ -360,6 +374,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(50.0)
                 .showLeaderboard(true)
                 .carryingCapacity(100)
+                .capacityPerUser(10)
                 .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant)
                 .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
                 .build();
@@ -401,6 +416,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(8.49)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(10)
                 .build();
 
         Commons commons = Commons.builder()
@@ -412,6 +428,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(8.49)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(10)
                 .build();
 
         String requestBody = objectMapper.writeValueAsString(parameters);
@@ -434,6 +451,8 @@ public class CommonsControllerTests extends ControllerTestCase {
         commons.setDegradationRate(parameters.getDegradationRate());
         parameters.setCarryingCapacity(123);
         commons.setCarryingCapacity(parameters.getCarryingCapacity());
+        parameters.setCapacityPerUser(10);
+        commons.setCapacityPerUser(parameters.getCapacityPerUser());
 
         requestBody = objectMapper.writeValueAsString(parameters);
 
@@ -467,6 +486,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(8.49)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(10)
                 .build();
 
         Commons commons = Commons.builder()
@@ -478,6 +498,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(8.49)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(10)
                 .build();
 
         String requestBody = objectMapper.writeValueAsString(parameters);


### PR DESCRIPTION
### Overview
Add a new field `CapacityPerUser` on the list, create and edit commons form that gives the admin the ability to specify a per-user capacity for each commons. This value currently does nothing, and is used to compute the value of another field `EffectiveCapacity`.

### Pages
List Commons Page:
<img width="1302" alt="image" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-1/assets/63994566/cfb5fbfe-43d2-4c4b-abb9-e5255e7b6925">

Create Commons Page:
<img width="1316" alt="image" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-1/assets/63994566/14c2f84a-2fe6-44f7-8b9a-4723a5eca2fd">

Edit Common Page:
<img width="1316" alt="image" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-1/assets/63994566/8e77deb1-5bff-4939-b8b7-fa90f2756e30">

### Issue
Closes the first part of #4 